### PR TITLE
Multiple Locations for Security Mode Security System

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ In external integrations like Homekit, the Arlo App Security Modes are exposed a
 
 For example, have all Arlo Cameras set to Stream & Record in the Home App both Home and Away in the Recording Options. Set up the Away Security Mode in the Arlo App to have all cameras send notifications. Set up the Home Security Mode in the Arlo App to only have the cameras you want to send notifications while you are at home. Set up the Standby Security Mode to have none of the cameras send notifications. Now, you can use Automations in the Home App to change the Security Mode of the Virtual Security System so that the Security Mode in the Arlo App changes and only sends notifications for the cameras you want based on your automations. HKSV Recordings are done based on the notifications so even though you are home according to the Home App and the camera is set to Stream & Record in the Home App, it will only record when Scrypted receives the notification.
 
+Multiple Security Systems are created, one for each location. A location is defined as a User Location, a location created on the account signed into Scrypted, and a Shared Location, a location that is shared from another account to the account signed into Scrypted. Each Location has a name in the Arlo App and this name is passed to Scrypted for identification.
+
 Note that this will not set up or modify settings of the Security Modes in the Arlo App, only change which one is active.
 
 ## Video Clips

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "@scrypted/arlo",
-   "version": "0.10.5",
+   "version": "0.10.6",
    "lockfileVersion": 2,
    "requires": true,
    "packages": {
       "": {
          "name": "@scrypted/arlo",
-         "version": "0.10.5",
+         "version": "0.10.6",
          "license": "Apache",
          "devDependencies": {
             "@scrypted/sdk": "^0.2.104"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "@scrypted/arlo",
-   "version": "0.10.5",
+   "version": "0.10.6",
    "description": "Arlo Plugin for Scrypted",
    "license": "Apache",
    "keywords": [

--- a/src/arlo_plugin/arlo/arlo_async.py
+++ b/src/arlo_plugin/arlo/arlo_async.py
@@ -1074,19 +1074,23 @@ class Arlo(object):
             }
         })
 
-    def GetMainLocation(self) -> str:
-        mainLocation = self._getMainLocation()
-        return mainLocation['sharedLocations'][0]['locationId']
+    def GetLocations(self) -> list:
+        locations = self._getLocations()
+        locationList = {}
+        for location in locations.keys():
+            for locationId in range(len(locations[f'{location}'])):
+                locationList[locations[f'{location}'][locationId]['locationId']] = locations[f'{location}'][locationId]['locationName']
+        return locationList
 
-    def GetCurrentMode(self, mainLocation: str) -> str:
+    def GetCurrentMode(self, location: str) -> str:
         currentmode = self._getCurrentMode_NextRevision()
-        return currentmode[f'{mainLocation}']['properties']['mode']
+        return currentmode[f'{location}']['properties']['mode']
 
-    def GetNextRevision(self, mainLocation: str) -> str:
+    def GetNextRevision(self, location: str) -> str:
         nextRevision = self._getCurrentMode_NextRevision()
-        return nextRevision[f'{mainLocation}']['revision']
+        return nextRevision[f'{location}']['revision']
 
-    def _getMainLocation(self) -> dict:
+    def _getLocations(self) -> dict:
         return self.request.get(f'https://{self.BASE_URL}/hmsdevicemanagement/users/{self.user_id}/locations')
 
     def _getCurrentMode_NextRevision(self) -> dict:
@@ -1099,7 +1103,7 @@ class Arlo(object):
         }
         return self.request.get(f'https://{self.BASE_URL}/hmsweb/automation/v3/activeMode?locationId=all', headers=headers)
 
-    def SetMode(self, setmode, mainLocation, nextrevision) -> None:
+    def SetMode(self, setmode, location, nextrevision) -> None:
         device_id = str(uuid.uuid4())
         headers = {
             'Origin': f'https://{self.BASE_URL}',
@@ -1110,7 +1114,7 @@ class Arlo(object):
         params = {
             'mode': setmode,
         }
-        self.request.put(f'https://{self.BASE_URL}/hmsweb/automation/v3/activeMode?locationId={mainLocation}&revision={nextrevision}', params=params, headers=headers)
+        self.request.put(f'https://{self.BASE_URL}/hmsweb/automation/v3/activeMode?locationId={location}&revision={nextrevision}', params=params, headers=headers)
         return
 
     def GetLibrary(self, device, from_date: datetime, to_date: datetime):

--- a/src/arlo_plugin/provider.py
+++ b/src/arlo_plugin/provider.py
@@ -779,37 +779,39 @@ class ArloProvider(ScryptedDeviceBase, Settings, DeviceProvider, ScryptedDeviceL
             self.logger.info(f"Discovered {len(cameras)} cameras")
 
         if self.mode_enabled:
-            nativeId = "Arlo.smss"
+            locations = self.arlo.GetLocations()
+            for location in locations:
+                nativeId = f'{location}.smss'
 
-            self.all_device_ids.add(f"Arlo Security Mode Security System ({nativeId})")
+                self.all_device_ids.add(f"Arlo Security Mode Security System ({nativeId})")
 
-            self.logger.debug(f"Adding {nativeId}")
+                self.logger.debug(f"Adding {nativeId}")
 
-            self.arlo_smss[nativeId] = ""
+                self.arlo_smss[nativeId] = ""
 
-            device = await self.getDevice_impl(nativeId)
-            scrypted_interfaces = device.get_applicable_interfaces()
-            manifest = {
-                "info": {
-                    "model": "Arlo Security Mode Security System",
-                    "manufacturer": "Arlo",
-                    "firmware": "1.0",
-                    "serialNumber": "000",
-                },
-                "nativeId": nativeId,
-                "name": "Arlo Security Mode Security System",
-                "interfaces": scrypted_interfaces,
-                "type": device.get_device_type(),
-                "providerNativeId": None,
-            }
+                device = await self.getDevice_impl(nativeId)
+                scrypted_interfaces = device.get_applicable_interfaces()
+                manifest = {
+                    "info": {
+                        "model": "Arlo Security Mode Security System",
+                        "manufacturer": "Arlo",
+                        "firmware": "1.0",
+                        "serialNumber": "000",
+                    },
+                    "nativeId": nativeId,
+                    "name": f'Arlo Security Mode Security System - {locations[location]}',
+                    "interfaces": scrypted_interfaces,
+                    "type": device.get_device_type(),
+                    "providerNativeId": None,
+                }
 
-            self.logger.debug(f"Interfaces for {nativeId}: {scrypted_interfaces}")
+                self.logger.debug(f"Interfaces for {nativeId}: {scrypted_interfaces}")
 
-            provider_to_device_map.setdefault(None, []).append(manifest)
+                provider_to_device_map.setdefault(None, []).append(manifest)
 
-            await scrypted_sdk.deviceManager.onDeviceDiscovered(manifest)
+                await scrypted_sdk.deviceManager.onDeviceDiscovered(manifest)
 
-            self.logger.info(f"Discovered 1 security mode security system")
+            self.logger.info(f"Discovered {len(locations)} security mode security systems")
 
         for provider_id in provider_to_device_map.keys():
             if provider_id is None:

--- a/src/arlo_plugin/provider.py
+++ b/src/arlo_plugin/provider.py
@@ -783,11 +783,19 @@ class ArloProvider(ScryptedDeviceBase, Settings, DeviceProvider, ScryptedDeviceL
             for location in locations:
                 nativeId = f'{location}.smss'
 
-                self.all_device_ids.add(f"Arlo Security Mode Security System ({nativeId})")
+                self.all_device_ids.add(f"Arlo Security Mode Security System - {locations[location]} ({nativeId})")
 
                 self.logger.debug(f"Adding {nativeId}")
 
+                if nativeId in self.arlo_smss:
+                    self.logger.info(f"Skipping security system {nativeId} (Arlo Security Mode Security System - {locations[location]}) as it has already been added")
+                    continue
+
                 self.arlo_smss[nativeId] = ""
+
+                if nativeId in self.hidden_device_ids:
+                    self.logger.info(f"Skipping security system {nativeId} (Arlo Security Mode Security System - {locations[location]}) because it is hidden")
+                    continue
 
                 device = await self.getDevice_impl(nativeId)
                 scrypted_interfaces = device.get_applicable_interfaces()

--- a/src/arlo_plugin/smss.py
+++ b/src/arlo_plugin/smss.py
@@ -22,7 +22,7 @@ class ArloSecurityModeSecuritySystem(ArloDeviceBase, SecuritySystem, Settings, R
 
     @property
     def location(self) -> str:
-        location = self.provider.arlo.GetMainLocation()
+        location = self.nativeId.replace('.smss', '')
         return location
 
     @location.setter


### PR DESCRIPTION
Ok, I've gone through and modified everything for the creation of the security systems. It now creates one security system for each location, this includes user locations which are created in the account and shared locations with the account. the plugin goes out, grabs the list of all locations, iterates through it to pull the location id and name down. Then a security system is created for each location and named according to the location name in the Arlo App.